### PR TITLE
Update cleanModelName.R

### DIFF
--- a/R/cleanModelName.R
+++ b/R/cleanModelName.R
@@ -45,7 +45,7 @@
         #order VID model names by decreasing length so that more specific models will be matched first. "328 GTS" matches before "328"
         modelNamesStripped <- removeNonLettersNumbers(modelName)
         if(mnStripped %in% modelNamesStripped){
-          returnThis <- modelName[mnStripped == modelNamesStripped]
+          returnThis <- modelName[mnStripped == modelNamesStripped][1]
         } else {
          for(m in modelName){
           mStripped <- removeNonLettersNumbers(m) #also strip any non letters or numbers from the VID model name


### PR DESCRIPTION
Will pick first option when multiple are suggested. This was causing a fatal error with R4.2